### PR TITLE
Make sure the path to the destination exists before writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var cheerio = require('cheerio'),
     events = require('events'),
     fs = require('fs'),
     gutil = require('gulp-util'),
+    mkdirp = require('mkdirp'),
     mustache = require('mustache'),
     packetr = require('./lib/packer.growing'),
     path = require('path'),
@@ -275,8 +276,9 @@ var spriteSVG = function(options) {
     // Render our template and then save the file
     function renderTemplate(file) {
         var compiled = mustache.render(file.contents, file.data);
-
-        fs.writeFile(file.dest, compiled);
+        mkdirp(path.dirname(file.dest), function(){
+            fs.writeFile(file.dest, compiled);
+        });
     }
 
     // Final processing of sprite sheet then we return file to gulp pipe

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "cheerio": "^0.17.0",
     "gulp-util": "^3.0.1",
+    "mkdirp": "latest",
     "mustache": "^0.8.2",
     "through2": "^0.6.3"
   }


### PR DESCRIPTION
I now get an error unless all the directories have been made. This is annoying when the destination folder is empty, as it won't exist in git, unless I add a `.gitignore` file in it. This pull requests uses mkdirp to create all the directories needed to the path first