### PR TITLE
Latest version of Node FS WriteFile requires callback unless using WritefileSync.

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ var spriteSVG = function(options) {
         var compiled = mustache.render(file.contents, file.data);
 
         mkdirp(path.dirname(file.dest)).then(() => {
-          fs.writeFile(file.dest, compiled);
+          fs.writeFileSync(file.dest, compiled);
         });
     }
 


### PR DESCRIPTION
As there was no callback defined, it makes sense to use WriteFileSync.
Using with the latest version of Yarn (1.22.4), this package causes errors, the above fixes that issue.